### PR TITLE
Add basic shopping cart API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ nopCommerce official site: [https://www.nopcommerce.com](https://www.nopcommerce
 * [Online course for developers](https://nopcommerce.com/training?utm_source=github&utm_medium=referral&utm_campaign=course&utm_content=links)
 * [Feature list](https://www.nopcommerce.com/features?utm_source=github&utm_medium=referral&utm_campaign=features&utm_content=links)
 * [Web API plugin](https://www.nopcommerce.com/web-api?utm_source=github&utm_medium=referral&utm_campaign=WebAPI&utm_content=links)
+* [Shopping cart API docs](docs/api.md)
 * [nopCommerce documentation](https://docs.nopcommerce.com?utm_source=github&utm_medium=referral&utm_campaign=documentation&utm_content=links)
 * [Community forums](https://www.nopcommerce.com/boards?utm_source=github&utm_medium=referral&utm_campaign=forum&utm_content=links)
 * [Premium support services](https://www.nopcommerce.com/nopcommerce-premium-support-services?utm_source=github&utm_medium=referral&utm_campaign=premium_support&utm_content=links)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,80 @@
+# nopCommerce Web API
+
+The new **nopCommerce Web API** project exposes REST endpoints for managing store data programmatically. It is intended for integrations with mobile apps or third‑party services and uses JWT authentication.
+
+## ShoppingCartApiController
+
+The `ShoppingCartApiController` provides endpoints for working with the shopping cart.
+
+### `GET /api/cart`
+Returns the current customer's cart.
+
+```
+GET /api/cart HTTP/1.1
+Authorization: Bearer {token}
+```
+
+Response example:
+```json
+{
+  "items": [
+    {"id": 1, "productId": 72, "quantity": 2}
+  ],
+  "totalQuantity": 2
+}
+```
+
+### `POST /api/cart/items`
+Adds a new item to the cart.
+
+```
+POST /api/cart/items HTTP/1.1
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+  "productId": 72,
+  "quantity": 1
+}
+```
+
+Response:
+```json
+{
+  "id": 5,
+  "productId": 72,
+  "quantity": 1
+}
+```
+
+### `PUT /api/cart/items/{id}`
+Updates quantity of an existing cart item.
+
+```
+PUT /api/cart/items/5 HTTP/1.1
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+  "quantity": 3
+}
+```
+
+Response:
+```json
+{
+  "id": 5,
+  "productId": 72,
+  "quantity": 3
+}
+```
+
+### `DELETE /api/cart/items/{id}`
+Removes a cart item.
+
+```
+DELETE /api/cart/items/5 HTTP/1.1
+Authorization: Bearer {token}
+```
+
+Response status: `204 No Content`.


### PR DESCRIPTION
## Summary
- document Web API project and `ShoppingCartApiController` routes in `docs/api.md`
- link the new doc from the README

## Testing
- `dotnet test -c Release --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688530580b20833395dc385bcbc6e093